### PR TITLE
Lint test specification files (spec.ts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build:browser": "webpack --config browser-build.config.js",
     "build": "tsc -p tsconfig.json && npm run build:browser",
-    "lint": "eslint -c .eslintrc.js --ext ts src/",
+    "lint": "eslint -c .eslintrc.js --ext ts,spec.ts src/",
     "typecheck": "tsc --noEmit --project tsconfig.json",
     "prebuild": "npm run test",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
Title says it all.

I am not sure why the aren't captured by the `ts` extension, but this makes them beeing considered for linting.