### PR TITLE
Fix missing source file warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": ".",
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
     "lib": [
       "dom",
       "es2017"


### PR DESCRIPTION
Fixes missing file warnings stemming from source map files.

Rel: https://github.com/geostyler/geostyler-style/pull/297