### PR TITLE
ci: remove pushing tag command from npm release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prebuild": "npm run test",
     "prepublishOnly": "npm run build",
     "pretest": "npm run lint && npm run typecheck",
-    "release": "np --no-yarn --any-branch && git push https://github.com/geostyler/geostyler-cql-parser.git master --tags",
+    "release": "np --no-yarn --any-branch",
     "start": "webpack --config webpack.config.js --watch",
     "test:watch": "jest --watchAll",
     "test": "jest --coverage"


### PR DESCRIPTION
Removes the command for pushing tags to the upstream repo since this is already included in the np command.