### PR TITLE
fix: use global if window is not available (2 of 2)

### DIFF
--- a/src/CqlParser.ts
+++ b/src/CqlParser.ts
@@ -92,8 +92,8 @@ export class CqlParser {
 
   read(text: string | undefined): Filter | Expression<PropertyType> | undefined {
     try {
-      // @ts-expect-error defined in the window object
-      return window.cqlParser.parse(text);
+      // @ts-expect-error cqlParser is defined in the window / global object - see cql-parser.cjs
+      return (typeof window !== 'undefined' ? window : global).cqlParser.parse(text);
     } catch (e) {
       return undefined;
     }


### PR DESCRIPTION
Completes a partial fix that was started in bab4242

Fixes an issue where CqlParser.read does nothing when run in a node environment, since there is no window object and therefore no object at `window.cqlParser`. This is the cause of https://github.com/geostyler/geostyler-cli/issues/419