### PR TITLE
fix: remove lodash and define isString locally

### DIFF
--- a/src/CqlParser.ts
+++ b/src/CqlParser.ts
@@ -4,12 +4,6 @@ import {
   isOperator
 } from 'geostyler-style';
 
-import {
-  isString as _isString,
-  isNumber as _isNumber,
-  isNaN as _isNaN
-} from 'lodash';
-
 import './cql-parser.cjs';
 
 import { CombinationOperator, Expression, Filter, Operator, PropertyType } from 'geostyler-style/dist/style';
@@ -33,6 +27,8 @@ type CombinationOperatorsReverseMap = {
 type PrecedenceMap = {
   [name: string]: 1 | 2 | 3;
 };
+
+const isString = (value: any) => typeof value === 'string';
 
 export class CqlParser {
 
@@ -158,7 +154,7 @@ export class CqlParser {
         case '<=':
         case '>':
         case '>=':
-          const valueIsString = _isString(f[2]);
+          const valueIsString = isString(f[2]);
           let value = f[2];
           if (valueIsString) {
             value = `'${value}'`;


### PR DESCRIPTION
When analyzing my bundle size, I saw a large chunk taken by lodash, which is used by your parser.

With this patch, lodash is replaced and the bundle size of my project became 550kB smaller.

You would think that Vite (what I use) would tree shake, especially because my project is created with Vite,
but tree shaking doesn't seem to work very well.

This is the second PR, the first one can be disregarded.